### PR TITLE
Fix direct links to search results

### DIFF
--- a/src/components/HomepageComponent.js
+++ b/src/components/HomepageComponent.js
@@ -11,31 +11,38 @@ require('styles/Homepage.scss');
 class HomepageComponent extends React.Component {
   constructor() {
     super();
+
     this.state = {
-      searchText: ''
+      'directSearch': false,
+      'searchText': null
     };
   }
 
   /**
+   * Before the Component is rendered, check if we have a query
+   * in the URL (direct link to a search results) and set the
+   * state appropriately.
+   */
+  componentWillMount() {
+    var query = this.props.location.query;
+
+    if (query.q) {
+      this.setState({
+        'directSearch': true,
+        'searchText': query.q
+      });
+    }
+  }
+
+  /**
    * Triggered when the search form is submitted
+   *
    * @param {String} searchText The text in the search field input box
    */
   handleSearch(searchText) {
-    /**
-     * FIXME: This shouldn't be here, just using
-     *        this space as a test
-     */
-    var intro = document.querySelector('.js-intro'),
-      search_results = document.querySelector('.js-search-results');
+    var intro = document.querySelector('.js-intro');
 
     intro.classList.add('slide-up');
-
-    window.setTimeout(function() {
-      search_results.classList.add('fade-in');
-    }, 1000);
-    /**
-     * End FIXME
-     */
 
     this.setState({
       searchText: searchText
@@ -48,18 +55,37 @@ class HomepageComponent extends React.Component {
   }
 
   render() {
-    return (
-      <main className="main-container homepage-component">
-        <div className="intro js-intro">
-          <h1 className="title">Ottawa Social Enterprise Directory</h1>
+    var intro = null,
+      searchResults = null;
 
-          <p className="tagline">
+    // Show intro if this isn't a direct link to a search
+    if (this.state.directSearch === false) {
+      intro = (
+        <div className='intro js-intro'>
+          <h1 className='title'>Ottawa Social Enterprise Directory</h1>
+
+          <p className='tagline'>
             Find goods and services from Ottawa's vibrant social enterprise sector.
           </p>
         </div>
+      );
+    }
 
-        <SearchForm onSearch={this.handleSearch.bind(this)} />
-        <SearchResults searchText={this.state.searchText} directory={this.props.directory} lunr_index={this.props.index} />
+    // If we are performing a search (direct or not), display the results
+    if (this.state.searchText !== null) {
+      searchResults = (
+        <SearchResults searchText={this.state.searchText} directSearch={this.state.directSearch}
+          directory={this.props.directory} lunr_index={this.props.index} />
+      );
+    }
+
+    return (
+      <main className='main homepage-component'>
+        {intro}
+
+        <SearchForm onSearch={this.handleSearch.bind(this)} searchText={this.state.searchText} />
+
+        {searchResults}
       </main>
     );
   }
@@ -74,4 +100,5 @@ HomepageComponent.displayName = 'HomepageComponent';
 // This is used by the Homepage and Template tests at the moment.
 // They don't like wrapped components.
 export let HomepageComponentWithoutRouter = HomepageComponent;
+
 export default withRouter(HomepageComponent);

--- a/src/components/SearchFormComponent.js
+++ b/src/components/SearchFormComponent.js
@@ -12,11 +12,18 @@ class SearchFormComponent extends React.Component {
       this.refs.searchTextInput.value
     );
   }
+
   render() {
+    var searchText = '';
+
+    if (this.props.searchText) {
+      searchText = this.props.searchText;
+    }
+
     return (
       <form className="search-form js-search-form searchform-component" onSubmit={this.handleSubmit.bind(this)}>
         <div className="search__field-button">
-          <input className="search-field" name="q" placeholder="Find Social Enterprises" type="search" ref="searchTextInput" />
+          <input className="search-field" name="q" placeholder="Find Social Enterprises" type="search" ref="searchTextInput" defaultValue={searchText} />
           <input className="search-button" type="submit" value="Search" />
         </div>
       </form>

--- a/src/components/SearchResultsComponent.js
+++ b/src/components/SearchResultsComponent.js
@@ -6,6 +6,19 @@ import Enterprise from './EnterpriseComponent.js';
 require('styles/SearchResults.scss');
 
 class SearchResultsComponent extends React.Component {
+  componentDidMount() {
+    var search_results = document.querySelector('.js-search-results');
+
+    // If this is a direct link to a search, don't fade, just show
+    if (this.props.directSearch === true) {
+      search_results.style.opacity = '1';
+    } else {
+      window.setTimeout(function() {
+        search_results.classList.add('fade-in');
+      }, 1000);
+    }
+  }
+
   render() {
     var _this = this,
       directory = _this.props.directory,

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -31,6 +31,10 @@ body {
   overflow-y: scroll;
 }
 
+.main {
+  padding-top: 40px;
+}
+
 .tint {
   background-color: rgba(0, 0, 0, 0.7);
 }
@@ -59,7 +63,7 @@ body {
     background-size: auto auto;
   }
 
-  .main-container {
+  .main {
     margin: 0 20px;
   }
 }

--- a/src/styles/Homepage.scss
+++ b/src/styles/Homepage.scss
@@ -20,6 +20,16 @@
   text-align: center;
 }
 
+.intro.slide-up {
+  padding-top: 0;
+  transition: padding-top 2s;
+}
+
+.intro.collapsed {
+  max-height: 0;
+  overflow: hidden;
+}
+
 /**
  * Mobile (smaller than iPad)
  */

--- a/test/components/HomepageComponentTest.js
+++ b/test/components/HomepageComponentTest.js
@@ -13,7 +13,7 @@ describe('HomepageComponent', () => {
   let component;
 
   beforeEach(() => {
-    component = createComponent(HomepageComponentWithoutRouter);
+    component = createComponent(HomepageComponentWithoutRouter, {location: {query: ''}});
   });
 
   it('should have its component name as default className', () => {


### PR DESCRIPTION
We now automatically display the relevant results when loading URLs like
http://example.org/?q=enterprise directly

(Closes #15)