### PR TITLE
require 'slug/slug-browser' instead of 'slug'

### DIFF
--- a/src/components/EnterprisePageComponent.js
+++ b/src/components/EnterprisePageComponent.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import Enterprise from './EnterpriseComponent.js';
 
-var slug = require('slug');
+var slug = require('slug/slug-browser');
 slug.defaults.mode = 'rfc3986';
 
 require('styles/EnterprisePage.scss');

--- a/src/components/EnterpriseSummaryComponent.js
+++ b/src/components/EnterpriseSummaryComponent.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router';
 
 require('styles/EnterpriseSummary.scss');
 
-var slug = require('slug');
+var slug = require('slug/slug-browser');
 slug.defaults.mode = 'rfc3986';
 
 class EnterpriseSummaryComponent extends React.Component {


### PR DESCRIPTION
This brings app.js filesize from 2MB to ~304KB since we're not pulling
the unicode dependency anymore.