### PR TITLE
styles: Create '.page', dedupe '.search-results'

### DIFF
--- a/src/components/DirectoryComponent.js
+++ b/src/components/DirectoryComponent.js
@@ -27,7 +27,7 @@ class DirectoryComponent extends React.Component {
     }
 
     return (
-      <ol className='directory-component'>
+      <ol className='directory-component page'>
         {jsx}
       </ol>
     );

--- a/src/components/EnterprisePageComponent.js
+++ b/src/components/EnterprisePageComponent.js
@@ -31,7 +31,7 @@ class EnterprisePageComponent extends React.Component {
     }
 
     return (
-      <div className="enterprise-details enterprisepage-component">
+      <div className="enterprisepage-component page">
         {jsx}
       </div>
     );

--- a/src/components/HomepageComponent.js
+++ b/src/components/HomepageComponent.js
@@ -80,13 +80,13 @@ class HomepageComponent extends React.Component {
     }
 
     return (
-      <main className='main homepage-component'>
+      <div className='homepage-component'>
         {intro}
 
         <SearchForm onSearch={this.handleSearch.bind(this)} searchText={this.state.searchText} />
 
         {searchResults}
-      </main>
+      </div>
     );
   }
 }

--- a/src/components/SearchResultsComponent.js
+++ b/src/components/SearchResultsComponent.js
@@ -58,7 +58,7 @@ class SearchResultsComponent extends React.Component {
     });
 
     return (
-      <ol className='search-results js-search-results searchresults-component'>
+      <ol className='search-results js-search-results searchresults-component page'>
         {jsx}
       </ol>
     );

--- a/src/components/TemplateComponent.js
+++ b/src/components/TemplateComponent.js
@@ -139,7 +139,9 @@ class TemplateComponent extends React.Component {
         <SiteNavigation />
 
         {/* The router will decide what to render here based on the URL we're at */}
-        {childWithProps}
+        <main className='main'>
+          {childWithProps}
+        </main>
       </div>
     );
   }

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -55,6 +55,14 @@ body {
   transition: opacity 4s;
 }
 
+.page {
+  background-color: #fff;
+  border-radius: 5px;
+  margin: 20px auto;
+  padding: 15px 30px;
+  width: 75%;
+}
+
 /**
  * Mobile (smaller than iPad)
  */
@@ -65,6 +73,13 @@ body {
 
   .main {
     margin: 0 20px;
+  }
+
+  .page {
+    border-radius: 0;
+    margin-left: -20px;
+    margin-right: -20px;
+    width: auto;
   }
 }
 

--- a/src/styles/Directory.scss
+++ b/src/styles/Directory.scss
@@ -1,14 +1,7 @@
-/* FIXME: .search-results dupe */
 .directory-component {
-  background-color: #fff;
-  border-radius: 5px;
   list-style-type: none;
-  margin: 20px auto;
-  padding: 15px 30px;
   text-align: left;
-  width: 75%;
 
-  /* FIXME: .search-result dupe */
   .directory-item {
     border-bottom: 1px solid #ddd;
     margin-top: 15px;

--- a/src/styles/EnterprisePage.scss
+++ b/src/styles/EnterprisePage.scss
@@ -1,17 +1,1 @@
-.enterprise-details {
-  background-color: #fff;
-  border-radius: 5px;
-  margin: 20px auto;
-  padding: 15px 30px;
-  width: 75%;
-}
-
-/**
- * Mobile (smaller than iPad)
- */
-@media only screen and (max-width: 768px) {
-  .enterprise-details {
-    border-radius: 0;
-    width: auto;
-  }
-}
+// Placeholder

--- a/src/styles/SearchResults.scss
+++ b/src/styles/SearchResults.scss
@@ -1,12 +1,7 @@
 .search-results {
-  background-color: #fff;
-  border-radius: 5px;
   list-style-type: none;
-  margin: 20px auto;
   opacity: 0;
-  padding: 15px 30px;
   text-align: left;
-  width: 75%;
 }
 
 .search-result {
@@ -17,17 +12,5 @@
 
 .search-result:last-child {
   border: 0;
-}
-
-/**
- * Mobile (smaller than iPad)
- */
-@media only screen and (max-width: 768px) {
-  .search-results {
-    border-radius: 0;
-    margin-left: -20px;
-    margin-right: -20px;
-    width: auto;
-  }
 }
 

--- a/test/components/DirectoryComponentTest.js
+++ b/test/components/DirectoryComponentTest.js
@@ -22,6 +22,6 @@ describe('DirectoryComponent', () => {
   });
 
   it('should have its component name as default className', () => {
-    expect(component.props.className).to.equal('directory-component');
+    expect(component.props.className.split(' ').indexOf('directory-component')).not.to.equal(-1);
   });
 });


### PR DESCRIPTION
The '.page' class takes care of applying the white background, rounded
corners and width styles.

This was originally part of '.search-results' and duplicated in
'.applicationform-component', '.directory-component' and
'enterprise-details'.