### PR TITLE
Detailed enterprise name links to external website

### DIFF
--- a/src/components/EnterpriseComponent.js
+++ b/src/components/EnterpriseComponent.js
@@ -177,7 +177,7 @@ class EnterpriseComponent extends React.Component {
 
     return (
       <div className="enterprise-component">
-        <EnterpriseSummary enterprise={this.props.enterprise} />
+        <EnterpriseSummary enterprise={this.props.enterprise} linkto='external' />
 
         {purposes}
 

--- a/src/components/EnterpriseSummaryComponent.js
+++ b/src/components/EnterpriseSummaryComponent.js
@@ -10,7 +10,12 @@ slug.defaults.mode = 'rfc3986';
 
 class EnterpriseSummaryComponent extends React.Component {
   render() {
-    var enterprise = this.props.enterprise;
+    var enterprise = this.props.enterprise,
+      enterprise_link = <Link to={'/enterprise/' + slug(enterprise.name)}>{enterprise.name}</Link>;
+
+    if (this.props.linkto === 'external') {
+      enterprise_link = <a href={enterprise.website}>{enterprise.name}</a>;
+    }
 
     return (
       <div className="enterprise-summary enterprisesummary-component">
@@ -20,7 +25,7 @@ class EnterpriseSummaryComponent extends React.Component {
         </div>
         <div className="enterprise__details">
           <h2 className="enterprise__title">
-            <Link to={'/enterprise/' + slug(enterprise.name)}>{enterprise.name}</Link>
+            {enterprise_link}
           </h2>
           <div className="enterprise__description">{enterprise.description}</div>
           <div className="enterprise__website">


### PR DESCRIPTION
This adds a 'linkto' property to EnterpriseSummary. If its value is
'external', then the link on the name of the enterprise links to their
website. Otherwise, like in the search results for example, it links
to the directory's 'detailed page' for that enterprise.