### PR TITLE
Reverse-proxy '/api' path to backend

### DIFF
--- a/cfg/base.js
+++ b/cfg/base.js
@@ -25,6 +25,12 @@ module.exports = {
     hot: true,
     port: defaultSettings.port,
     publicPath: defaultSettings.publicPath,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:10010',
+        secure: false
+      }
+    },
     noInfo: false
   },
   resolve: {


### PR DESCRIPTION
So it matches our prod environment more closely.