### PR TITLE
build: Open browser outside 'live-reload' env.

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,5 +13,5 @@ new WebpackDevServer(webpack(config), config.devServer)
   }
   console.log('Listening at localhost:' + config.port);
   console.log('Opening your system browser...');
-  open('http://localhost:' + config.port + '/webpack-dev-server/');
+  open('http://localhost:' + config.port + '/');
 });


### PR DESCRIPTION
Since the /webpack-dev-server/ path uses an iframe, it doesn't work well
with:

1. react-router (the URL doesn't get updated)
2. the Twitter oauth page since it has `X-Frame-Options:"SAMEORIGIN"`
HTTP headers