### PR TITLE
display enterprises correctly on map

### DIFF
--- a/src/components/EnterpriseMapComponent.js
+++ b/src/components/EnterpriseMapComponent.js
@@ -17,9 +17,10 @@ class EnterpriseMapComponent extends React.Component {
     let tileLayer = this.generateTileLayer();
 
     if (enterprise.locations.coordinates.length === 1) {
+      let latLng = [enterprise.locations.coordinates[0][1], enterprise.locations.coordinates[0][0]];
       return (
         <div className="enterprisemap-component">
-          <Map center={enterprise.locations.coordinates[0]} zoom={15}>
+          <Map center={latLng} zoom={15}>
             {tileLayer}
             {popupMarkers}
           </Map>
@@ -29,7 +30,7 @@ class EnterpriseMapComponent extends React.Component {
 
     return (
       <div className="enterprisemap-component">
-        <Map bounds={enterprise.locations.coordinates}>
+        <Map bounds={this.generateAllCoords(enterprise)}>
           {tileLayer}
           {popupMarkers}
         </Map>
@@ -49,9 +50,10 @@ class EnterpriseMapComponent extends React.Component {
   generatePopupMarkers(enterprise) {
     let jsx = [];
     enterprise.locations.coordinates.map(coordinates => {
-      let coordsStr = coordinates[0] + ',' + coordinates[1];
+      let latLng = [coordinates[1], coordinates[0]];
+      let coordsStr = latLng[0] + ',' + latLng[1];
       jsx.push(
-        <Marker key={coordsStr} position={coordinates}>
+        <Marker key={coordsStr} position={latLng}>
           <Popup>
             <span>{enterprise.name}</span>
           </Popup>
@@ -59,6 +61,15 @@ class EnterpriseMapComponent extends React.Component {
       );
     });
     return jsx;
+  }
+
+  generateAllCoords(enterprise) {
+    let allCoords = [];
+    enterprise.locations.coordinates.map(coordinates => {
+      let latLng = [coordinates[1], coordinates[0]];
+      allCoords.push(latLng);
+    });
+    return allCoords;
   }
 }
 

--- a/src/components/SearchResultsMapComponent.js
+++ b/src/components/SearchResultsMapComponent.js
@@ -17,10 +17,10 @@ class SearchResultsMapComponent extends React.Component {
   renderSearchNearCoords(tileLayer, popupMarkers) {
     // get search coords in lat/long order
     let coords = this.props.searchCoords.split(',').map(parseFloat);
-    coords = [coords[1], coords[0]];
+    let latLng = [coords[1], coords[0]];
     return (
       <div className="searchresultsmap-component">
-        <Map center={coords} zoom={11}>
+        <Map center={latLng} zoom={11}>
           {tileLayer}
           {popupMarkers}
         </Map>
@@ -70,7 +70,8 @@ class SearchResultsMapComponent extends React.Component {
         return;
       }
       enterprise.locations.coordinates.map(coordinates => {
-        allCoords.push(coordinates);
+        let latLng = [coordinates[1], coordinates[0]];
+        allCoords.push(latLng);
       });
     });
     return allCoords;
@@ -92,8 +93,9 @@ class SearchResultsMapComponent extends React.Component {
         return;
       }
       enterprise.locations.coordinates.map(coordinates => {
+        let latLng = [coordinates[1], coordinates[0]];
         jsx.push(
-          <Marker key={coordinates.toString()} position={coordinates}>
+          <Marker key={enterprise.name + latLng.toString()} position={latLng}>
             <Popup>
               <span>{enterprise.name}</span>
             </Popup>


### PR DESCRIPTION
The backend returns coords in long/lat format to be consistent with GeoJSON formatted points. However, leaflet requires lat/long format. I'm surprised I didn't notice this bug sooner... 

I'm not sure how rtto repo is being updated, but we'll probably need to port this fix over there too.